### PR TITLE
拡大画像の不具合修正、スマホの時注意を表示するなどの変更

### DIFF
--- a/src/app.vue
+++ b/src/app.vue
@@ -1,13 +1,36 @@
 <template>
   <div>
     <router-view />
+    <o-notification
+      v-if="deviseWidth < 900"
+      class="alertBottom"
+      closable
+      variant="warning"
+      aria-close-label="Close notification"
+    >
+      このサイトはPC(スクリーンの幅が900px以上)向けです。
+    </o-notification>
   </div>
 </template>
 
 <script>
 export default {
-  mounted() {
-    window.app = this
+  computed: {
+    deviseWidth() {
+      return window.screen.width;
+    },
   },
-}
+  mounted() {
+    window.app = this;
+  },
+};
 </script>
+
+<style lang="scss" scoped>
+.alertBottom {
+  width: 100%;
+  position: fixed;
+  bottom: 0;
+  margin-bottom: 0;
+}
+</style>

--- a/src/assets/scss/layout.scss
+++ b/src/assets/scss/layout.scss
@@ -1,13 +1,26 @@
-@import url('../../../node_modules/github-markdown-css/github-markdown-light.css');
+@import url("../../../node_modules/github-markdown-css/github-markdown-light.css");
 
 body {
 }
 .app-wrapper {
   position: relative;
   overflow-x: scroll;
+  // スクロールバーのスタイル
+  ::-webkit-scrollbar {
+    width: 4px;
+    height: 8px;
+  }
+  ::-webkit-scrollbar-track {
+    background-color: lightgray;
+    border-radius: 10px;
+}
+  ::-webkit-scrollbar-thumb {
+    border-radius: 10px;
+    background: rgba(0, 0, 0, 0.8);
+  }
 }
 .main {
-    margin-left: 10px;
+  margin-left: 10px;
 }
 
 #canvas {

--- a/src/assets/scss/layout.scss
+++ b/src/assets/scss/layout.scss
@@ -7,7 +7,7 @@ body {
   overflow-x: scroll;
   // スクロールバーのスタイル
   ::-webkit-scrollbar {
-    width: 4px;
+    width: 8px;
     height: 8px;
   }
   ::-webkit-scrollbar-track {

--- a/src/components/BattleZone.vue
+++ b/src/components/BattleZone.vue
@@ -91,6 +91,13 @@
             >
             <template v-else>
               <o-button
+                v-if="card.isChojigen"
+                variant="grey-dark"
+                size="small"
+                @click.stop="setCardState(card, { faceDown: !card.faceDown })"
+                >裏返す</o-button
+              >
+              <o-button
                 variant="grey-dark"
                 size="small"
                 @click.stop="
@@ -101,19 +108,12 @@
                 "
                 >重ねる</o-button
               >
-              <o-button
-                v-if="card.isChojigen"
-                variant="grey-dark"
-                size="small"
-                @click.stop="setCardState(card, { faceDown: !card.faceDown })"
-                >裏返す</o-button
-              >
             </template>
           </template>
           <o-button
             v-if="card.faceDown && !card.isChojigen"
             variant="grey-dark"
-            @click.stop="card.faceDown = !card.faceDown"
+            @click.stop="setCardState(card, { faceDown: !card.faceDown })"
             >裏返す</o-button
           >
           <!-- アンタップ or タップ -->

--- a/src/components/BattleZone.vue
+++ b/src/components/BattleZone.vue
@@ -89,18 +89,26 @@
               @click.stop="clickCard($event, card)"
               >キャンセル</o-button
             >
-            <o-button
-              v-else
-              variant="grey-dark"
-              size="small"
-              @click.stop="
-                setSelectMode({
-                  ...selectMode,
-                  selectingTarget: true,
-                })
-              "
-              >重ねる</o-button
-            >
+            <template v-else>
+              <o-button
+                variant="grey-dark"
+                size="small"
+                @click.stop="
+                  setSelectMode({
+                    ...selectMode,
+                    selectingTarget: true,
+                  })
+                "
+                >重ねる</o-button
+              >
+              <o-button
+                v-if="card.isChojigen"
+                variant="grey-dark"
+                size="small"
+                @click.stop="setCardState(card, { faceDown: !card.faceDown })"
+                >裏返す</o-button
+              >
+            </template>
           </template>
           <o-button
             v-if="card.faceDown && !card.isChojigen"

--- a/src/components/DeckZone.vue
+++ b/src/components/DeckZone.vue
@@ -47,7 +47,7 @@
     </template>
     <template v-if="yamafudaCards.length > 0">
       <o-dropdown-item aria-role="listitem" @click="openDeck"
-        >開く</o-dropdown-item
+        >山札を確認</o-dropdown-item
       >
       <o-dropdown-item
         aria-role="listitem"

--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -10,7 +10,10 @@
         class="imageDisplay_image"
         :style="{ width: `${style.width}px` }"
       >
-        <img v-if="hoveredCard.faceDown" :src="hoveredCard.backImageUrl" />
+        <img
+          v-if="hoveredCard.faceDown && !hoveredCard.showInWorkSpace"
+          :src="hoveredCard.backImageUrl"
+        />
         <img v-else :src="hoveredCard.imageUrl" />
       </div>
       <div
@@ -92,24 +95,24 @@ export default {
     },
     cardText() {
       /** @type {String} */
-      const text = this.hoveredCard.text
+      const text = this.hoveredCard.text;
       if (this.hoveredCard && text) {
         if (this.hoveredCard.faceDown) {
           if (this.hoveredCard.backText) {
-            return this.hoveredCard.backText
+            return this.hoveredCard.backText;
           }
           if (text.match(/─{3,}龍解後─{3,}/)) {
-            return text.split(/─{3,}龍解後─{3,}/)[1]
+            return text.split(/─{3,}龍解後─{3,}/)[1];
           }
         } else {
           if (text.match(/─{3,}龍解後─{3,}/)) {
-            return text.split(/─{3,}龍解後─{3,}/)[0]
+            return text.split(/─{3,}龍解後─{3,}/)[0];
           }
         }
-        return text
+        return text;
       }
-      return ''
-    }
+      return "";
+    },
   },
   methods: {
     ...mapMutations(["setHoveredCard"]),

--- a/src/components/ShieldZone.vue
+++ b/src/components/ShieldZone.vue
@@ -126,12 +126,16 @@ export default {
 .shield-zone {
   background-color: rgb(79, 205, 255);
   width: 275px;
-  height: cardHeight(50px);
+  height: cardHeight(50px) + 8px;
   display: flex;
   flex-direction: row-reverse;
   position: relative;
   overflow-x: scroll;
   margin-right: 8px;
+  &::-webkit-scrollbar {
+    // 下のスクロールバーの幅だけスクロール可能になっているので消す。
+    width: 0px;
+  }
   > * {
     margin-right: 2px;
   }

--- a/src/components/TefudaZone.vue
+++ b/src/components/TefudaZone.vue
@@ -170,8 +170,10 @@ $card-width: 70px;
   .tefuda-zone {
     height: 100%;
     display: flex;
-    overflow-x: scroll;
     max-width: 410px;
+    &.upper {
+      overflow-x: auto;
+    }
     .card_wrapper {
       position: relative;
     }

--- a/src/components/WorkSpace.vue
+++ b/src/components/WorkSpace.vue
@@ -432,7 +432,7 @@ $card-width: 120px;
     .workSpace_inner {
       max-width: 100px;
       max-height: 100px;
-      overflow-y: scroll;
+      overflow-y: auto;
     }
     .bottomMenu {
       display: none;
@@ -441,7 +441,7 @@ $card-width: 120px;
   &_inner {
     // height: 60vh;
     max-height: 60vh;
-    overflow-y: scroll;
+    overflow-y: auto;
     @media screen and (max-device-width: 700px) {
       margin: 0;
       max-width: 100vw;

--- a/src/helpers/mixin.js
+++ b/src/helpers/mixin.js
@@ -22,6 +22,15 @@ mixin.zone = {
       // 状態を送信
       this.emitState();
     },
+    setCardState(card, cardState) {
+      Object.keys(cardState).forEach((key) => {
+        if (['tapped', 'faceDown'].includes(key)) {
+          card[key] = cardState[key];
+        }
+      })
+      // 状態を送信
+      this.emitState();
+    },
     setMarkColor(card, color) {
       this.setSelectMode(null);
       card.markColor = color;

--- a/src/main.js
+++ b/src/main.js
@@ -14,9 +14,6 @@ vueApp.use(router)
 import store from './store'
 vueApp.use(store)
 
-// マウント
-vueApp.mount('#app')
-
 //
 // useConfig
 import useConfig from './plugins/useConfig'
@@ -48,3 +45,7 @@ vueApp.component('Dropdown', Dropdown)
 // markdown
 import Markdown from './plugins/markdown'
 vueApp.use(Markdown)
+
+//
+// マウント
+vueApp.mount('#app')

--- a/src/plugins/oruga.js
+++ b/src/plugins/oruga.js
@@ -1,10 +1,10 @@
-import { Modal, Icon, Dropdown, Button, Config, Input, Field, Tooltip } from '@oruga-ui/oruga-next'
+import { Modal, Icon, Dropdown, Button, Config, Input, Field, Tooltip, Notification } from '@oruga-ui/oruga-next/dist/esm'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import '../assets/scss/oruga.scss'
 
 export function useOruga(vueApp) {
   vueApp.component('vue-fontawesome', FontAwesomeIcon)
-  vueApp.use(Modal).use(Icon).use(Dropdown).use(Button).use(Input).use(Field).use(Tooltip)
+  vueApp.use(Modal).use(Icon).use(Dropdown).use(Button).use(Input).use(Field).use(Tooltip).use(Notification)
   // https://github.com/oruga-ui/oruga/issues/99#issuecomment-794784783
   // How to set icon pack for Individual components (tree shaking) ?
   vueApp.use(Config, {


### PR DESCRIPTION
# 対応内容
- スクロールバーのスタイルを修正
- 拡大画像がカード裏の画像になるバグの修正
- 超次元ゾーンから出したカードに裏返すボタンを追加
- スクリーン幅の小さいデバイスの場合警告を表示する